### PR TITLE
frontend-324: - unnesessary liveMaxLatencyDuration that fas-forwarded…

### DIFF
--- a/frontend/src/components/common/video-player/video-player-controls/progress-bar/progress-bar.tsx
+++ b/frontend/src/components/common/video-player/video-player-controls/progress-bar/progress-bar.tsx
@@ -12,8 +12,8 @@ type Props = {
   liveSyncLie: boolean;
 };
 
-// if current time is within 4s from live edge, snap the bar to the end
-const LIVE_SYNC_LIE_SPAN_SEC = 4;
+// if current time is within 5s from live edge, snap the bar to the end
+const LIVE_SYNC_LIE_SPAN_SEC = 5;
 
 const ProgressBar: FC<Props> = ({ videoContainer, className, liveSyncLie }) => {
   const dispatch = useAppDispatch();

--- a/frontend/src/components/common/video-player/video-player.tsx
+++ b/frontend/src/components/common/video-player/video-player.tsx
@@ -107,7 +107,6 @@ const VideoPlayer: FC<VideoPlayerProps> = ({
         // according to docs: "value too low (inferior to ~3 segment durations) is likely to cause playback stalls"
         // if this is a problem, value may be returned to 3, which will make the video start 6 seconds before live point
         liveSyncDuration: 0,
-        liveMaxLatencyDuration: 0.5,
         // ideally, there should be some modifications in the playlist file
         // when the video turns offline, that would differentiate it from live video
         // and let the player start from start automatically


### PR DESCRIPTION
… video whenever it was behind the end